### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker-flow.yml
+++ b/.github/workflows/docker-flow.yml
@@ -17,7 +17,7 @@ jobs:
 
     # Publishes our image to Docker Hub 😎
     - name: Publish to Docker Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         # the name of our image
         name: chaitanyak59/go-git-actions


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore